### PR TITLE
refactor explorer CLI with modular design

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "playwright-extra": "^4.3.6",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
         "tesseract.js": "^5.1.0",
-        "yaml": "^2.4.5"
+        "yaml": "^2.4.5",
+        "yargs": "^17.7.2"
       },
       "devDependencies": {
         "@types/node": "^20.14.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "playwright-extra": "^4.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
     "tesseract.js": "^5.1.0",
-    "yaml": "^2.4.5"
+    "yaml": "^2.4.5",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@types/node": "^20.14.2",

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,1 +1,3 @@
 declare module 'playwright-extra-plugin-stealth';
+declare module 'yargs';
+declare module 'yargs/helpers';

--- a/src/explorer/output.ts
+++ b/src/explorer/output.ts
@@ -1,0 +1,6 @@
+import { mkdir, writeFile } from 'fs/promises';
+
+export async function writePlaybookFile(filePath: string, contents: string): Promise<void> {
+  await mkdir('playbooks', { recursive: true });
+  await writeFile(filePath, contents);
+}

--- a/src/explorer/scanner.ts
+++ b/src/explorer/scanner.ts
@@ -1,0 +1,19 @@
+import { Page } from 'playwright';
+import { findConsentSelectors, findSearchSelectors } from './heuristics';
+
+export interface SelectorResults {
+  consentSelectors: string[];
+  searchSelectors: string[];
+}
+
+export async function scanSelectors(page: Page): Promise<SelectorResults> {
+  console.log('Scanning for consent selectors...');
+  const consentSelectors = await findConsentSelectors(page);
+  console.log(`Found ${consentSelectors.length} potential consent selectors.`);
+
+  console.log('Scanning for search selectors...');
+  const searchSelectors = await findSearchSelectors(page);
+  console.log(`Found ${searchSelectors.length} potential search selectors.`);
+
+  return { consentSelectors, searchSelectors };
+}

--- a/src/orchestrator/worker.ts
+++ b/src/orchestrator/worker.ts
@@ -28,6 +28,13 @@ async function executeAction(page: Page, action: Action): Promise<void> {
       const target = action.selector ? anyPage.locator(action.selector) : anyPage;
       await target.press(action.key);
       break;
+    case 'type':
+      await anyPage.locator(action.selector).type(action.text, {
+        delay: action.delay_ms_range
+          ? (action.delay_ms_range[0] + action.delay_ms_range[1]) / 2
+          : undefined,
+      });
+      break;
     case 'click':
       await human.click(anyPage, action.selector);
       break;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type FinishAction = { action: 'finish'; reason: string };
 export type Action =
   | GotoAction
   | WaitStableAction
+  | TypeAction
   | KeypressAction
   | HumanScrollAction
   | ClickAction


### PR DESCRIPTION
## Summary
- refactor explorer entrypoint into parseArgs/runExplorer with yargs-based CLI parsing
- modularize selector scanning and playbook file writing
- extend Action types and orchestrator to handle typing events

## Testing
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c2d14f9308321aa95418276c3a82d